### PR TITLE
+ limpio, constantes y bug arreglado

### DIFF
--- a/PortalCompras_Forcing Completion.sol
+++ b/PortalCompras_Forcing Completion.sol
@@ -3,66 +3,68 @@ pragma solidity ^0.6.0;
 
 contract portalcompras_Forcing_Completion {
     
-address payable public owner;
-producto[16]   productos;
-
-struct producto {
+    address payable public vendedor;
+    producto[16] productos;
+    enum Estado {Pagado, Enviado, Entregado}
+    uint256 constant garantia = 5 ether;
+    uint256 constant precio = 1 ether;
     
-    address payable  comprador;
-	uint256  estado; //1 pago, 2 enviado,3 entregado
-    uint256  Fecha_pago;
-    uint256  Fecha_envio;
-    uint256  Fecha_recepcion;
-}
-
-constructor() payable public {
-require(msg.value == 80.00 ether);
-owner = msg.sender;
-
-}
-
-function Compra (uint256 id_producto) external payable {
-    require(id_producto >= 0 && id_producto <= 15);
-    require(productos[id_producto].comprador == address(0x0));
-    require(msg.value == 6.00 ether);
-    productos[id_producto]= producto(msg.sender,1,block.timestamp,0,0);
-}
-
-function envio(uint256 id_producto) public {
-    require(id_producto >= 0 && id_producto <= 15);
-    require(msg.sender == owner);
-    require(productos[id_producto].estado==1);
-    productos[id_producto].estado= 2;
-    productos[id_producto].Fecha_envio=block.timestamp;
-}
-
-function confirma_entrega(uint256 id_producto) external payable {
-    require(id_producto >= 0 && id_producto <= 15);
-    require(productos[id_producto].comprador == msg.sender);
-    require(productos[id_producto].estado==2);
-    productos[id_producto].estado= 3;
-    productos[id_producto].Fecha_recepcion=block.timestamp;
-    productos[id_producto].comprador.transfer(5 ether);
-    owner.transfer(6 ether);
-
-}
-
-function resuelve_conflictos  (uint256 id_producto) external payable {
-    require(id_producto >= 0 && id_producto <= 15);
-    require(productos[id_producto].comprador == msg.sender || msg.sender == owner);
-    
-        if (block.timestamp  > (productos[id_producto].Fecha_pago + 1 minutes) && productos[id_producto].estado == 1 ) {
-            productos[id_producto].comprador.transfer(6 ether);
-            address(0x0).transfer(5 ether);
-            owner.transfer(6 ether);  
-            productos[id_producto].comprador=address(0x0);
-        
-        } else if (block.timestamp  > (productos[id_producto].Fecha_envio + 1 minutes) && productos[id_producto].estado == 2 ) {
-        
-            address(0x0).transfer(5 ether);
-            owner.transfer(5 ether);   
-        }
-        
+    struct producto {
+        address payable comprador;
+        Estado  estado;
+        uint256 fecha_pago;
+        uint256 fecha_envio;
+        uint256 fecha_recepcion;
     }
-
+    
+    constructor() payable public {
+        require(msg.value == productos.length * garantia);
+        vendedor = msg.sender;
+    }
+    
+    function productoValido(uint256 id_producto) internal view returns (bool) {
+        return id_producto >= 0 && id_producto < productos.length;
+    }
+    
+    function compra(uint256 id_producto) external payable {
+        require(productoValido(id_producto));
+        require(productos[id_producto].comprador == address(0x0));
+        require(msg.value == (precio + garantia));
+        productos[id_producto] = producto(msg.sender, Estado.Pagado, block.timestamp, 0, 0);
+    }
+    
+    function envio(uint256 id_producto) public {
+        require(productoValido(id_producto));
+        require(msg.sender == vendedor);
+        require(productos[id_producto].estado == Estado.Pagado);
+        productos[id_producto].estado = Estado.Enviado;
+        productos[id_producto].fecha_envio = block.timestamp;
+    }
+    
+    function confirma_entrega(uint256 id_producto) external payable {
+        require(productoValido(id_producto));
+        require(productos[id_producto].comprador == msg.sender);
+        require(productos[id_producto].estado == Estado.Enviado);
+        productos[id_producto].estado = Estado.Entregado;
+        productos[id_producto].fecha_recepcion = block.timestamp;
+        productos[id_producto].comprador.transfer(garantia);
+        vendedor.transfer(garantia + precio);
+    }
+    
+    function resuelve_conflictos (uint256 id_producto) external payable {
+        require(productoValido(id_producto));
+        require(productos[id_producto].comprador == msg.sender || msg.sender == vendedor);
+        
+        if (block.timestamp > (productos[id_producto].fecha_pago + 1 minutes) && productos[id_producto].estado == Estado.Pagado) {
+            productos[id_producto].comprador.transfer(garantia + precio);
+            address(0x0).transfer(garantia);
+            productos[id_producto].comprador = address(0x0);
+        
+        } else if (block.timestamp  > (productos[id_producto].fecha_envio + 1 minutes) && productos[id_producto].estado == Estado.Enviado) {
+            address(0x0).transfer(garantia);
+            vendedor.transfer(garantia);   
+        }
+            
+    }
+    
  }


### PR DESCRIPTION
previamente en la lógica de resolución de conflictos, cuando
estaba pagado y el tiempo había pasado un minuto, quemaba
los 5 ethers del vendedor pero procedía a transferirle 6

también cambie los estados a enum en vez de números